### PR TITLE
feat: Use main bundle localized key/values first if available

### DIFF
--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -403,7 +403,10 @@ ORK_EXTERN NSBundle *ORKBundle(void) ORK_AVAILABLE_DECL;
 ORK_EXTERN NSBundle *ORKDefaultLocaleBundle(void);
 
 ORK_INLINE NSString *ORKLocalizedHiddenString(NSString *key) {
-    NSString *value = [[NSBundle mainBundle] localizedStringForKey:key value:key table:nil];
+    NSString *value = [[NSBundle mainBundle] localizedStringForKey:key value:key table:@"ResearchKit"];
+    if ([value isEqualToString:key]) {
+        value = [[NSBundle mainBundle] localizedStringForKey:key value:key table:nil];
+    }
     if ([value isEqualToString:key]) {
         value = [ORKBundle() localizedStringForKey:key value:key table:@"ResearchKit"];
     }

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -403,7 +403,10 @@ ORK_EXTERN NSBundle *ORKBundle(void) ORK_AVAILABLE_DECL;
 ORK_EXTERN NSBundle *ORKDefaultLocaleBundle(void);
 
 ORK_INLINE NSString *ORKLocalizedHiddenString(NSString *key) {
-    NSString *value = [ORKBundle() localizedStringForKey:key value:key table:@"ResearchKit"];
+    NSString *value = [[NSBundle mainBundle] localizedStringForKey:key value:key table:nil];
+    if ([value isEqualToString:key]) {
+        value = [ORKBundle() localizedStringForKey:key value:key table:@"ResearchKit"];
+    }
     if ([value isEqualToString:key]) {
         // If it fails try to find on default table
         value = [ORKDefaultLocaleBundle() localizedStringForKey:key value:key table:@"ResearchKit"];


### PR DESCRIPTION
Updated the internal helper method `ORKLocalizedString()` to check if a string key exists in the main bundle localization tables before checking for the key in the ResearchKit localization tables.

Addresses issue https://github.com/ResearchKit/ResearchKit/issues/1601